### PR TITLE
Fix travis miniconda crap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ install:
   - export PYTHONUNBUFFERED=true
 
 script:
-  - conda config --add channels https://conda.binstar.org/omnia
+  - conda config --add channels omnia
   - conda build devtools/conda-recipe
 
 env:
   matrix:
-    - python=2.7  CONDA_PY=2
-    - python=3.3  CONDA_PY=33
+    - python=2.7  CONDA_PY=27
     - python=3.4  CONDA_PY=34
+    - python=3.5  CONDA_PY=35
 
   global:
     # encrypted BINSTAR_TOKEN for push of dev package to binstar

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - conda config --add channels ${ORGNAME}
   - conda build devtools/conda-recipe
   - source activate _test
+  - conda install --yes --quiet nose nose-timer
   - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-doctest --with-timer && cd ..
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,17 @@ install:
   - source devtools/travis-ci/install.sh
   - export PYTHONUNBUFFERED=true
 
+install:
+  - source devtools/travis-ci/install.sh
+  - export PYTHONUNBUFFERED=true
+  - export CC=gcc
+  - export CXX=g++
+
 script:
-  - conda config --add channels omnia
+  - conda config --add channels ${ORGNAME}
   - conda build devtools/conda-recipe
+  - source activate _test
+  - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-doctest --with-timer && cd ..
 
 env:
   matrix:
@@ -20,6 +28,8 @@ env:
     - python=3.5  CONDA_PY=35
 
   global:
+    - PACKAGENAME="torsionfit"
+    - ORGNAME="omnia"
     # encrypted BINSTAR_TOKEN for push of dev package to binstar
 
 after_success:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - openmm >=6.3
     - parmed
     - setuptools
+    - mdtraj
 
   run:
     - python
@@ -22,6 +23,7 @@ requirements:
     - openmm >=6.3
     - parmed
     - pandas
+    - mdtraj
 
 test:
   requires:

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -5,10 +5,10 @@ if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"
     exit 1
 fi
-bash $MINICONDA -b
+bash $MINICONDA -b -p miniconda
 
 
 export PATH=$HOME/miniconda/bin:$PATH
 conda install --yes conda-build jinja2 anaconda-client pip
-conda config --add channels http://conda.binstar.org/omnia
+conda config --add channels omnia
 

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -1,5 +1,5 @@
 # Temporarily move to $HOME directory
-pushd
+pushd .
 cd $HOME
 
 MINICONDA=Miniconda-latest-Linux-x86_64.sh

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -1,5 +1,7 @@
-pwd
-echo `$HOME`
+# Temporarily move to $HOME directory
+pushd
+cd $HOME
+
 MINICONDA=Miniconda-latest-Linux-x86_64.sh
 MINICONDA_MD5=$(curl -s http://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget http://repo.continuum.io/miniconda/$MINICONDA
@@ -10,8 +12,8 @@ fi
 bash $MINICONDA -b -p miniconda
 
 export PATH=$HOME/miniconda/bin:$PATH
-which conda
-ls $HOME/miniconda/bin
 conda install --yes conda-build jinja2 anaconda-client pip
 conda config --add channels omnia
 
+# Return to original directory
+popd

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -6,7 +6,7 @@ if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     exit 1
 fi
 bash $MINICONDA -b -p miniconda
-
+ls -ltr
 
 export PATH=$HOME/miniconda/bin:$PATH
 conda install --yes conda-build jinja2 anaconda-client pip

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -5,10 +5,12 @@ if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"
     exit 1
 fi
+cd $HOME
 bash $MINICONDA -b -p miniconda
-ls -ltr
 
 export PATH=$HOME/miniconda/bin:$PATH
+which conda
+ls $HOME/miniconda/bin
 conda install --yes conda-build jinja2 anaconda-client pip
 conda config --add channels omnia
 

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -1,3 +1,5 @@
+pwd
+echo `$HOME`
 MINICONDA=Miniconda-latest-Linux-x86_64.sh
 MINICONDA_MD5=$(curl -s http://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget http://repo.continuum.io/miniconda/$MINICONDA
@@ -5,7 +7,6 @@ if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"
     exit 1
 fi
-cd $HOME
 bash $MINICONDA -b -p miniconda
 
 export PATH=$HOME/miniconda/bin:$PATH

--- a/torsionfit/example.py
+++ b/torsionfit/example.py
@@ -2,7 +2,7 @@
 import simtk.openmm as mm
 
 # ParmEd imports
-from chemistry.charmm.parameters import CharmmParameterSet
+from parmed.charmm.parameters import CharmmParameterSet
 #import cProfile
 #import pstats
 #import StringIO


### PR DESCRIPTION
This fixes the fact that the default `miniconda` python2.7 directory now unpacks to `miniconda2` instead of `miniconda`.