### PR TITLE
Use OESubSearch to map atoms

### DIFF
--- a/torsionfit/qmscan/utils.py
+++ b/torsionfit/qmscan/utils.py
@@ -307,15 +307,21 @@ def mol_to_tagged_smiles(infile, outfile):
 
 def get_atom_map(tagged_smiles, molecule=None):
     """
-
+    Returns a dictionary that maps tag on SMILES to atom index in molecule.
     Parameters
     ----------
-    tagged_smiles
-    molecule
+    tagged_smiles: str
+        index-tagged explicit hydrogen SMILES string
+    molecule: OEMol
+        molecule to generate map for. If None, a new OEMol will be generated from the tagged SMILES, the map will map to
+        this molecule and it will be returned.
 
     Returns
     -------
-
+    atom_map: dict
+        a dictionary that maps tag to atom index {tag:idx}
+    molecule: OEMol
+        If a molecule was not provided, the generated molecule will be returned.
     """
     if molecule is None:
         molecule = openeye.smiles_to_oemol(tagged_smiles)
@@ -341,23 +347,31 @@ def get_atom_map(tagged_smiles, molecule=None):
     mol = oechem.OEGraphMol()
     oechem.OESubsetMol(mol, match, True)
     logger().info("Match SMILES: {}".format(oechem.OEMolToSmiles(mol)))
+    if molecule is None:
+        return molecule, atom_map
 
     return atom_map
 
 
-def to_mapped_xyz(molecule, atom_map, conformer=None, xyz_format=False, to_file=False):
+def to_mapped_xyz(molecule, atom_map, conformer=None, xyz_format=False, filename=None):
     """
     Generate xyz coordinates for molecule in the order given by the atom_map. atom_map is a dictionary that maps the
     tag on the SMILES to the atom idex in OEMol.
     Parameters
     ----------
-    molecule
-    atom_map
-    conformer
+    molecule: OEMol with conformers
+    atom_map: dict
+        maps tag in SMILES to atom index
+    conformer: int
+        Which conformer to write xyz file for. If None, write out all conformers. Default is None
+    xyz_format: bool
+        If True, will write out number of atoms and molecule name. If false, will only write out elements and coordinates
+    filename: str
+        Name of file to save to. If None, only returns a string.
 
     Returns
     -------
-    str: XYZ file format
+    str: elements and xyz coordinates in order of tagged SMILES
 
     """
     xyz = ""
@@ -379,8 +393,8 @@ def to_mapped_xyz(molecule, atom_map, conformer=None, xyz_format=False, to_file=
                                                                            coords[idx * 3 + 1],
                                                                            coords[idx * 3 + 2])
 
-    if to_file:
-        file = open("{}.xyz".format(molecule.GetTitle()), 'w')
+    if filename:
+        file = open("{}.xyz".format(filename, 'w'))
         file.write(xyz)
         file.close()
     return xyz

--- a/torsionfit/tests/test_qmscan.py
+++ b/torsionfit/tests/test_qmscan.py
@@ -119,6 +119,6 @@ class TestQmscan(unittest.TestCase):
         atom_map_mol2 = {1:0, 2:1, 3:2, 4:3, 5:4, 6:5, 7:6, 8:7, 9:8, 10:9, 11:10, 12:11, 13:12, 14:13, 15:14}
         xyz_2 = utils.to_mapped_xyz(mol_2, atom_map_mol2)
 
-        for ele1, ele2 in zip(xyz_1.split('\n')[3:], xyz_2.split('\n')[3:]):
+        for ele1, ele2 in zip(xyz_1.split('\n')[:-1], xyz_2.split('\n')[:-1]):
             self.assertEqual(ele1.split(' ')[2], ele2.split(' ')[2])
 

--- a/torsionfit/tests/test_qmscan.py
+++ b/torsionfit/tests/test_qmscan.py
@@ -96,6 +96,20 @@ class TestQmscan(unittest.TestCase):
             atom_2.SetAtomicNum(i+1)
             self.assertEqual(oechem.OECreateCanSmiString(mol_1), oechem.OECreateCanSmiString(mol_2))
 
+    @unittest.skipUnless(has_openeye, "Cannot test without OpenEye")
+    def test_atom_map_order(self):
+        """Test atom map"""
+        from openeye import oechem
+        tagged_smiles = '[H:5][C:1]#[N+:4][C:3]([H:9])([H:10])[C:2]([H:6])([H:7])[H:8]'
+        mol_from_tagged_smiles = openeye.smiles_to_oemol(tagged_smiles)
+        atom_map = utils.get_atom_map(tagged_smiles, mol_from_tagged_smiles)
+
+        # Compare atom map to tag
+        for i in range(1, len(atom_map) +1):
+            atom_1 = mol_from_tagged_smiles.GetAtom(oechem.OEHasAtomIdx(atom_map[i]))
+            self.assertEqual(i, atom_1.GetMapIdx())
+
+
     @unittest.skipUnless(has_openeye, "Cannot test without OpneEye")
     def test_mapped_xyz(self):
         """Test writing out mapped xyz"""


### PR DESCRIPTION
`OEMCSearch` is very slow and has trouble handling chiral centers. It also mismatches symmetric hydrogens. This PR replaces it with `OESubSearch`. 

OMCSearch benchmark on clinical kinase inhibitors:
https://github.com/ChayaSt/torsionfit_examples/blob/wbo/kinase_inhibitors/bond_order/mccs_time.png

OESubSearch benchmark on the same set:
https://github.com/ChayaSt/torsionfit_examples/blob/wbo/kinase_inhibitors/bond_order/ss_time.png